### PR TITLE
Fix action builds

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -15,9 +15,8 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup Swift
-      uses: fwal/setup-swift@v1.14.0
+    - uses: actions/checkout@v3
+    - uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,8 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Swift
-      uses: fwal/setup-swift@v1.14.0
+    - uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,39 @@
   "object": {
     "pins": [
       {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "cd142fd2f64be2100422d658e7411e39489da985",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "9bf03ff58ce34478e66aaee630e491823326fd06",
+          "version": "1.1.3"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "2bae395344d41710dffab456265d534d7dc34ab8",
-          "version": "2.25.0"
+          "revision": "9746cf80e29edfef2a39924a66731249223f42a3",
+          "version": "2.72.0"
+        }
+      },
+      {
+        "package": "swift-system",
+        "repositoryURL": "https://github.com/apple/swift-system.git",
+        "state": {
+          "branch": null,
+          "revision": "d2ba781702a1d8285419c15ee62fd734a9437ff5",
+          "version": "1.3.2"
         }
       }
     ]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 </div>
 <br />
 
-
 ![macOS](https://github.com/swiftpackages/DotEnv/workflows/macOS/badge.svg)
 ![ubuntu](https://github.com/swiftpackages/DotEnv/workflows/ubuntu/badge.svg)
 ![docs](https://github.com/swiftpackages/DotEnv/workflows/docs/badge.svg)


### PR DESCRIPTION
Tests are still passing on latest OSs and swift versions, but there is an issue with the action build. This fixes it by moving to [swift-actions/setup-swift](https://github.com/swift-actions/setup-swift)